### PR TITLE
Update js/jquery.calendario.js

### DIFF
--- a/js/jquery.calendario.js
+++ b/js/jquery.calendario.js
@@ -302,7 +302,7 @@
 		// goes to month/year
 		goto : function( month, year, callback ) {
 
-			this.month = month;
+			this.month = month - 1;
 			this.year = year;
 			this._generateTemplate( callback );
 


### PR DESCRIPTION
Not a bug, but it could be more user-friendly..?

Comply with examples.
cal.setData( {
    '03-01-2013' : '<a href="#">testing</a>',
    '03-10-2013' : '<a href="#">testing</a>',
    '03-12-2013' : '<a href="#">testing</a>'
} );
// goes to a specific month/year
cal.goto( 3, 2013, updateMonthYear );
