### PR TITLE
Removes usage of reserved JavaScript keyword.

### DIFF
--- a/js/jquery.calendario.js
+++ b/js/jquery.calendario.js
@@ -300,7 +300,7 @@
 
 		},
 		// goes to month/year
-		goto : function( month, year, callback ) {
+		gotoDirect : function( month, year, callback ) {
 
 			this.month = month - 1;
 			this.year = year;


### PR DESCRIPTION
The goto method caused a compilation error when attempting to build our
app. Removes usage of goto as a method name. Replaced with gotoDirect.
