### PR TITLE
Bugfix Calendario

### DIFF
--- a/js/jquery.calendario.js
+++ b/js/jquery.calendario.js
@@ -78,7 +78,7 @@
 						monthname : self.options.displayMonthAbbr ? self.options.monthabbrs[ self.month ] : self.options.months[ self.month ],
 						year : self.year,
 						weekday : idx + self.options.startIn,
-						weekdayname : self.options.weeks[ idx + self.options.startIn ]
+						weekdayname : self.options.weeks[ (idx==6?0:idx + self.options.startIn) ]
 					};
 
 				if( dateProp.day ) {


### PR DESCRIPTION
Fixed small bug on line 81. dateProp.weekdayname would be undefined if it's sunday (idx+self.options.startIn would be 7 and thus the options.weeks array would return undefined)
