### PR TITLE
Adds support for multiple events on the same day

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -13,5 +13,10 @@ var codropsEvents = {
 	'02-DD-2014' : {content : '<span>Ex: {\'02-DD-2014\' : {content : \'Something\', start : 10, end : 20}}</span>', start : 10, end : 20},
 	'12-DD-YYYY' : '<span>[12-DD-YYYY] Whole month and Year</span>',
 	'TODAY' : '<span>Today, [Date : \'TODAY\']</span>',
-	'10-16-2014': ['<a href="">event one</a>', '<span>event two</span>']
+	'10-16-2014': ['<a href="">event one</a>', '<span>event two</span>'],
+	'10-DD-YYYY' : [
+		{content : '<span>Ex: {\'10-DD-2014\' : {content : \'Something\', start : 10, end : 20}}</span>', start : 10, end : 20},
+		{content : '<span>Ex: {\'10-DD-2014\' : {content : \'Something\', start : 10, end : 20}}</span>', end: 20},
+	]
+
 };

--- a/js/data.js
+++ b/js/data.js
@@ -12,5 +12,6 @@ var codropsEvents = {
 	'11-DD-2014' : {content : '<span>Ex: {\'11-DD-2014\' : {content : \'Something\', end : 20}}</span>', end : 20},
 	'02-DD-2014' : {content : '<span>Ex: {\'02-DD-2014\' : {content : \'Something\', start : 10, end : 20}}</span>', start : 10, end : 20},
 	'12-DD-YYYY' : '<span>[12-DD-YYYY] Whole month and Year</span>',
-	'TODAY' : '<span>Today, [Date : \'TODAY\']</span>'
+	'TODAY' : '<span>Today, [Date : \'TODAY\']</span>',
+	'10-16-2014': ['<a href="">event one</a>', '<span>event two</span>']
 };

--- a/js/jquery.calendario.js
+++ b/js/jquery.calendario.js
@@ -228,99 +228,73 @@
 							}
 						}
 						if( dayDataMonthlyYear ) {
-							if( dayDataMonthlyYear['start'] && dayDataMonthlyYear['end'] )
-							{
-								if( (day >= dayDataMonthlyYear['start']) && (day <= dayDataMonthlyYear['end']) ) {
-									if (Array.isArray(dayDataMonthlyYear['content'])) {
-										content += this._convertDayArray(dayDataMonthlyYear['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthlyYear['content']);
-									}
-								}
+							if ( ! Array.isArray(dayDataMonthlyYear)) {
+								dayDataMonthlyYear = [dayDataMonthlyYear];
 							}
-							else if( dayDataMonthlyYear['start'] > 1 )
-							{
-								if( day >= dayDataMonthlyYear['start'] ) {
-									if (Array.isArray(dayDataMonthlyYear['content'])) {
-										content += this._convertDayArray(dayDataMonthlyYear['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthlyYear['content']);
+
+							for (var k = 0; k < dayDataMonthlyYear.length; k++) {
+								if( dayDataMonthlyYear[k]['start'] && dayDataMonthlyYear[k]['end'] )
+								{
+									if( (day >= dayDataMonthlyYear[k]['start']) && (day <= dayDataMonthlyYear[k]['end']) ) {
+										content += this._wrapDay(dayDataMonthlyYear[k]['content']);
 									}
 								}
-							}
-							else if( dayDataMonthlyYear['end'] > 0 )
-							{
-								if( day <= dayDataMonthlyYear['end'] ) {
-									if (Array.isArray(dayDataMonthlyYear['content'])) {
-										content += this._convertDayArray(dayDataMonthlyYear['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthlyYear['content']);
+								else if( dayDataMonthlyYear[k]['start'] > 1 )
+								{
+									if( day >= dayDataMonthlyYear[k]['start'] ) {
+										content += this._wrapDay(dayDataMonthlyYear[k]['content']);
 									}
 								}
-							}
-							else
-							{
-								if( dayDataMonthlyYear['content'] ) {
-									if (Array.isArray(dayDataMonthlyYear['content'])) {
-										content += this._convertDayArray(dayDataMonthlyYear['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthlyYear['content']);
+								else if( dayDataMonthlyYear[k]['end'] > 0 )
+								{
+									if( day <= dayDataMonthlyYear[k]['end'] ) {
+										content += this._wrapDay(dayDataMonthlyYear[k]['content']);
 									}
 								}
-								else {
-									if (Array.isArray(dayDataMonthlyYear)) {
-										content += this._convertDayArray(dayDataMonthlyYear);
-									} else {
-										content += this._wrapDay(dayDataMonthlyYear);
+								else
+								{
+									if( dayDataMonthlyYear[k]['content'] ) {
+										content += this._wrapDay(dayDataMonthlyYear[k]['content']);
+									}
+									else {
+										content += this._wrapDay(dayDataMonthlyYear[k]);
 									}
 								}
 							}
 						}
 						if( dayDataMonthly ) {
-							if( dayDataMonthly['start'] && dayDataMonthly['end'] )
-							{
-								if( (day >= dayDataMonthly['start']) && (day <= dayDataMonthly['end']) ) {
-									if (Array.isArray(dayDataMonthly['content'])) {
-										content += this._convertDayArray(dayDataMonthly['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthly['content']);
-									}
-								}
+
+							if ( ! Array.isArray(dayDataMonthly)) {
+								dayDataMonthly = [dayDataMonthly];
 							}
-							else if( dayDataMonthly['start'] > 1 )
-							{
-								if( day >= dayDataMonthly['start'] ) {
-									if (Array.isArray(dayDataMonthly['content'])) {
-										content += this._convertDayArray(dayDataMonthly['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthly['content']);
+
+							for (var k = 0; k < dayDataMonthly.length; k++) {
+								if( dayDataMonthly[k]['start'] && dayDataMonthly[k]['end'] )
+								{
+									if( (day >= dayDataMonthly[k]['start']) && (day <= dayDataMonthly[k]['end']) ) {
+										content += this._wrapDay(dayDataMonthly[k]['content']);
 									}
 								}
-							}
-							else if( dayDataMonthly['end'] > 0 )
-							{
-								if(day <= dayDataMonthly['end']) {
-									if (Array.isArray(dayDataMonthly['content'])) {
-										conten += this._convertDayArray(dayDataMonthly['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthly['content']);
+								else if( dayDataMonthly[k]['start'] > 1 )
+								{
+									if( day >= dayDataMonthly[k]['start'] ) {
+										content += this._wrapDay(dayDataMonthly[k]['content']);
 									}
 								}
-							}
-							else
-							{
-								if( dayDataMonthly['content'] ) {
-									if (Array.isArray(dayDataMonthly['content'])) {
-										content += this._convertDayArray(dayDataMonthly['content']);
-									} else {
-										content += this._wrapDay(dayDataMonthly['content']);
+								else if( dayDataMonthly[k]['end'] > 0 )
+								{
+									if(day <= dayDataMonthly[k]['end']) {
+										content += this._wrapDay(dayDataMonthly[k]['content']);
 									}
 								}
-								else {
-									if (Array.isArray(dayDataMonthly)) {
-										content += this._convertDayArray(dayDataMonthly);
+								else
+								{
+									if( dayDataMonthly[k]['content'] ) {
+										content += this._wrapDay(dayDataMonthly[k]['content']);
 									}
-									content += this._wrapDay(dayDataMonthly);
+									else {
+										content += this._wrapDay(dayDataMonthly[k]);
+									}
 								}
 							}
 						}

--- a/js/jquery.calendario.js
+++ b/js/jquery.calendario.js
@@ -154,6 +154,10 @@
 			return '<div class="fc-calendar-event">' + day + '</div>';
 		},
 
+		_convertDayArray: function (day) {
+			return this._wrapDay(day.join('</div><div class="fc-calendar-event">'));
+		},
+
 		_getBody : function() {
 
 			var d = new Date( this.year, this.month + 1, 0 ),
@@ -201,68 +205,138 @@
 						
 						if( today ) {
 							var dayDataToday = this.caldata[ "TODAY" ];
-							if( dayDataToday )
-								content += this._wrapDay(dayDataToday);
+							if( dayDataToday ) {
+								if (Array.isArray(dayDataToday)) {
+									content += this._convertDayArray(dayDataToday);
+								} else {
+									content += this._wrapDay(dayDataToday);
+								}
+							}
 						}
 						if( dayData ) {
-							content += this._wrapDay(dayData);
+							if (Array.isArray(dayData)) {
+								content += this._convertDayArray(dayData);
+							} else {
+								content += this._wrapDay(dayData);
+							}
 						}
 						if( dayDataMonth ) {
-							content += this._wrapDay(dayDataMonth);
+							if (Array.isArray(dayDataMonth)) {
+								content += this._convertDayArray(dayDataMonth);
+							} else {
+								content += this._wrapDay(dayDataMonth);
+							}
 						}
 						if( dayDataMonthlyYear ) {
 							if( dayDataMonthlyYear['start'] && dayDataMonthlyYear['end'] )
 							{
-								if( (day >= dayDataMonthlyYear['start']) && (day <= dayDataMonthlyYear['end']) )
-									content += this._wrapDay(dayDataMonthlyYear['content']);
+								if( (day >= dayDataMonthlyYear['start']) && (day <= dayDataMonthlyYear['end']) ) {
+									if (Array.isArray(dayDataMonthlyYear['content'])) {
+										content += this._convertDayArray(dayDataMonthlyYear['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthlyYear['content']);
+									}
+								}
 							}
 							else if( dayDataMonthlyYear['start'] > 1 )
 							{
-								if( day >= dayDataMonthlyYear['start'] )
-									content += this._wrapDay(dayDataMonthlyYear['content']);
+								if( day >= dayDataMonthlyYear['start'] ) {
+									if (Array.isArray(dayDataMonthlyYear['content'])) {
+										content += this._convertDayArray(dayDataMonthlyYear['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthlyYear['content']);
+									}
+								}
 							}
 							else if( dayDataMonthlyYear['end'] > 0 )
 							{
-								if( day <= dayDataMonthlyYear['end'] )
-									content += this._wrapDay(dayDataMonthlyYear['content']);
+								if( day <= dayDataMonthlyYear['end'] ) {
+									if (Array.isArray(dayDataMonthlyYear['content'])) {
+										content += this._convertDayArray(dayDataMonthlyYear['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthlyYear['content']);
+									}
+								}
 							}
 							else
 							{
-								if( dayDataMonthlyYear['content'] )
-									content += this._wrapDay(dayDataMonthlyYear['content']);
-								else
-									content += this._wrapDay(dayDataMonthlyYear);
+								if( dayDataMonthlyYear['content'] ) {
+									if (Array.isArray(dayDataMonthlyYear['content'])) {
+										content += this._convertDayArray(dayDataMonthlyYear['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthlyYear['content']);
+									}
+								}
+								else {
+									if (Array.isArray(dayDataMonthlyYear)) {
+										content += this._convertDayArray(dayDataMonthlyYear);
+									} else {
+										content += this._wrapDay(dayDataMonthlyYear);
+									}
+								}
 							}
 						}
 						if( dayDataMonthly ) {
 							if( dayDataMonthly['start'] && dayDataMonthly['end'] )
 							{
-								if( (day >= dayDataMonthly['start']) && (day <= dayDataMonthly['end']) )
-									content += this._wrapDay(dayDataMonthly['content']);
+								if( (day >= dayDataMonthly['start']) && (day <= dayDataMonthly['end']) ) {
+									if (Array.isArray(dayDataMonthly['content'])) {
+										content += this._convertDayArray(dayDataMonthly['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthly['content']);
+									}
+								}
 							}
 							else if( dayDataMonthly['start'] > 1 )
 							{
-								if( day >= dayDataMonthly['start'] )
-									content += this._wrapDay(dayDataMonthly['content']);
+								if( day >= dayDataMonthly['start'] ) {
+									if (Array.isArray(dayDataMonthly['content'])) {
+										content += this._convertDayArray(dayDataMonthly['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthly['content']);
+									}
+								}
 							}
 							else if( dayDataMonthly['end'] > 0 )
 							{
-								if(day <= dayDataMonthly['end'])
-									content += this._wrapDay(dayDataMonthly['content']);
+								if(day <= dayDataMonthly['end']) {
+									if (Array.isArray(dayDataMonthly['content'])) {
+										conten += this._convertDayArray(dayDataMonthly['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthly['content']);
+									}
+								}
 							}
 							else
 							{
-								if( dayDataMonthly['content'] )
-									content += this._wrapDay(dayDataMonthly['content']);
-								else
+								if( dayDataMonthly['content'] ) {
+									if (Array.isArray(dayDataMonthly['content'])) {
+										content += this._convertDayArray(dayDataMonthly['content']);
+									} else {
+										content += this._wrapDay(dayDataMonthly['content']);
+									}
+								}
+								else {
+									if (Array.isArray(dayDataMonthly)) {
+										content += this._convertDayArray(dayDataMonthly);
+									}
 									content += this._wrapDay(dayDataMonthly);
+								}
 							}
 						}
 						if( dayDataMonthYear ) {
-							content += this._wrapDay(dayDataMonthYear);
+							if (Array.isArray(dayDataMonthYear)) {
+								content += this._convertDayArray(dayDataMonthYear);
+							} else {
+								content += this._wrapDay(dayDataMonthYear);
+							}
 						}
 						if( dayDataYear ) {
-							content += this._wrapDay(dayDataYear);
+							if (Array.isArray(dayDataYear)) {
+								content += this._convertDayArray(dayDataYear);
+							} else {
+								content += this._wrapDay(dayDataYear);
+							}
 						}
 
 						if( content !== '' ) {

--- a/js/jquery.calendario.js
+++ b/js/jquery.calendario.js
@@ -149,6 +149,11 @@
 			return html;
 
 		},
+
+		_wrapDay: function (day) {
+			return '<div class="fc-calendar-event">' + day + '</div>';
+		},
+
 		_getBody : function() {
 
 			var d = new Date( this.year, this.month + 1, 0 ),
@@ -197,71 +202,71 @@
 						if( today ) {
 							var dayDataToday = this.caldata[ "TODAY" ];
 							if( dayDataToday )
-								content += dayDataToday;
+								content += this._wrapDay(dayDataToday);
 						}
 						if( dayData ) {
-							content += dayData;
+							content += this._wrapDay(dayData);
 						}
 						if( dayDataMonth ) {
-							content += dayDataMonth;
+							content += this._wrapDay(dayDataMonth);
 						}
 						if( dayDataMonthlyYear ) {
 							if( dayDataMonthlyYear['start'] && dayDataMonthlyYear['end'] )
 							{
 								if( (day >= dayDataMonthlyYear['start']) && (day <= dayDataMonthlyYear['end']) )
-									content += dayDataMonthlyYear['content'];
+									content += this._wrapDay(dayDataMonthlyYear['content']);
 							}
 							else if( dayDataMonthlyYear['start'] > 1 )
 							{
 								if( day >= dayDataMonthlyYear['start'] )
-									content += dayDataMonthlyYear['content'];
+									content += this._wrapDay(dayDataMonthlyYear['content']);
 							}
 							else if( dayDataMonthlyYear['end'] > 0 )
 							{
 								if( day <= dayDataMonthlyYear['end'] )
-									content += dayDataMonthlyYear['content'];
+									content += this._wrapDay(dayDataMonthlyYear['content']);
 							}
 							else
 							{
 								if( dayDataMonthlyYear['content'] )
-									content += dayDataMonthlyYear['content'];
+									content += this._wrapDay(dayDataMonthlyYear['content']);
 								else
-									content += dayDataMonthlyYear;
+									content += this._wrapDay(dayDataMonthlyYear);
 							}
 						}
 						if( dayDataMonthly ) {
 							if( dayDataMonthly['start'] && dayDataMonthly['end'] )
 							{
 								if( (day >= dayDataMonthly['start']) && (day <= dayDataMonthly['end']) )
-									content += dayDataMonthly['content'];
+									content += this._wrapDay(dayDataMonthly['content']);
 							}
 							else if( dayDataMonthly['start'] > 1 )
 							{
 								if( day >= dayDataMonthly['start'] )
-									content += dayDataMonthly['content'];
+									content += this._wrapDay(dayDataMonthly['content']);
 							}
 							else if( dayDataMonthly['end'] > 0 )
 							{
 								if(day <= dayDataMonthly['end'])
-									content += dayDataMonthly['content'];
+									content += this._wrapDay(dayDataMonthly['content']);
 							}
 							else
 							{
 								if( dayDataMonthly['content'] )
-									content += dayDataMonthly['content'];
+									content += this._wrapDay(dayDataMonthly['content']);
 								else
-									content += dayDataMonthly;
+									content += this._wrapDay(dayDataMonthly);
 							}
 						}
 						if( dayDataMonthYear ) {
-							content += dayDataMonthYear;
+							content += this._wrapDay(dayDataMonthYear);
 						}
 						if( dayDataYear ) {
-							content += dayDataYear;
+							content += this._wrapDay(dayDataYear);
 						}
 
 						if( content !== '' ) {
-							inner += '<div>' + content + '</div>';
+							inner += '<div class="fc-calendar-events">' + content + '</div>';
 						}
 
 						++day;


### PR DESCRIPTION
Excellent calendar but I needed support for multiple events on the same day so I implemented it.
Just specify an array of events. The old way still works.

I think I covered all the different way to specify events.

example:

``` javascript
var events = {
    '11-07-2014': 'Old way still works',
    '11-08-2014': ['<a href="">event one</a>', '<span>event two</span>']
}
```
