### PR TITLE
Remove a trailing comma of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "calendario",
   "version": "2.0.0",
-  "homepage": "http://tympanus.net/codrops/2012/11/27/calendario-a-flexible-calendar-plugin/",
+  "homepage": "http://tympanus.net/codrops/2012/11/27/calendario-a-flexible-calendar-plugin/"
 }


### PR DESCRIPTION
Fixed small bug when bower install.
trailing comma exists in bower.json occurs 'Unexpected token } ' error